### PR TITLE
Fix issue #16 + missing xmlTextWriterFlush() and Linux code not supporting prefix nor namespace

### DIFF
--- a/src/common/xmlhelpers.cpp
+++ b/src/common/xmlhelpers.cpp
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="xmlhelpers.cpp" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -389,6 +389,7 @@ namespace odata { namespace edm {
 #else // LINUX
         xmlChar *memory;
         int size;
+	xmlTextWriterFlush(m_writer); 
         xmlDocDumpMemory(m_doc, &memory, &size);
         *m_stream << memory;
         xmlFree(memory);
@@ -408,9 +409,17 @@ namespace odata { namespace edm {
             throw std::runtime_error(msg);
         }
 #else 
-        xmlChar* valueXml = (xmlChar*) ::odata::utility::conversions::to_utf8string(elementName).c_str();
-        xmlTextWriterStartElement(m_writer, valueXml);
-        xmlFree(valueXml);
+        xmlChar* valueXmlName = (xmlChar*) ::odata::utility::conversions::to_utf8string(elementName).c_str();
+	if(elementPrefix.empty())
+	{
+	  xmlTextWriterStartElement(m_writer,valueXmlName);
+	}
+	else
+	{
+	  xmlChar* valueXmlPrefix = (xmlChar*) ::odata::utility::conversions::to_utf8string(elementPrefix).c_str();
+	  xmlChar* valueXmlNamespace = namespaceName.empty() ? NULL : (xmlChar*) ::odata::utility::conversions::to_utf8string(namespaceName).c_str();
+	  xmlTextWriterStartElementNS(m_writer,valueXmlPrefix,valueXmlName,valueXmlNamespace);
+	}
 #endif
     }
 
@@ -502,9 +511,16 @@ namespace odata { namespace edm {
 #else
         xmlChar* nameXml = (xmlChar*) ::odata::utility::conversions::to_utf8string(name).c_str();
         xmlChar* valueXml = (xmlChar*) ::odata::utility::conversions::to_utf8string(value).c_str();
-        xmlTextWriterWriteAttribute(m_writer, nameXml, valueXml);
-        xmlFree(nameXml);
-        xmlFree(valueXml);
+	if(prefix.empty())
+	{
+	  xmlTextWriterWriteAttribute(m_writer, nameXml, valueXml);
+	}
+	else
+	{
+	  xmlChar* valueXmlPrefix = (xmlChar*) ::odata::utility::conversions::to_utf8string(prefix).c_str();
+	  xmlChar* valueXmlNamespace = namespaceUri.empty() ? NULL : (xmlChar*) ::odata::utility::conversions::to_utf8string(namespaceUri).c_str();
+	  xmlTextWriterWriteAttributeNS(m_writer, valueXmlPrefix, nameXml, valueXmlNamespace, valueXml);
+	}
 #endif
     }
 

--- a/src/common/xmlhelpers.cpp
+++ b/src/common/xmlhelpers.cpp
@@ -410,13 +410,13 @@ namespace odata { namespace edm {
         }
 #else 
         xmlChar* valueXmlName = (xmlChar*) ::odata::utility::conversions::to_utf8string(elementName).c_str();
-	if(elementPrefix.empty())
+	if(elementPrefix.empty() && namespaceName.empty())
 	{
 	  xmlTextWriterStartElement(m_writer,valueXmlName);
 	}
 	else
 	{
-	  xmlChar* valueXmlPrefix = (xmlChar*) ::odata::utility::conversions::to_utf8string(elementPrefix).c_str();
+	  xmlChar* valueXmlPrefix = elementPrefix.empty() ? NULL :(xmlChar*) ::odata::utility::conversions::to_utf8string(elementPrefix).c_str(); //CBE
 	  xmlChar* valueXmlNamespace = namespaceName.empty() ? NULL : (xmlChar*) ::odata::utility::conversions::to_utf8string(namespaceName).c_str();
 	  xmlTextWriterStartElementNS(m_writer,valueXmlPrefix,valueXmlName,valueXmlNamespace);
 	}

--- a/src/common/xmlhelpers.cpp
+++ b/src/common/xmlhelpers.cpp
@@ -389,7 +389,7 @@ namespace odata { namespace edm {
 #else // LINUX
         xmlChar *memory;
         int size;
-	xmlTextWriterFlush(m_writer); 
+        xmlTextWriterFlush(m_writer); 
         xmlDocDumpMemory(m_doc, &memory, &size);
         *m_stream << memory;
         xmlFree(memory);
@@ -410,16 +410,16 @@ namespace odata { namespace edm {
         }
 #else 
         xmlChar* valueXmlName = (xmlChar*) ::odata::utility::conversions::to_utf8string(elementName).c_str();
-	if(elementPrefix.empty() && namespaceName.empty())
-	{
-	  xmlTextWriterStartElement(m_writer,valueXmlName);
-	}
-	else
-	{
-	  xmlChar* valueXmlPrefix = elementPrefix.empty() ? NULL :(xmlChar*) ::odata::utility::conversions::to_utf8string(elementPrefix).c_str(); //CBE
-	  xmlChar* valueXmlNamespace = namespaceName.empty() ? NULL : (xmlChar*) ::odata::utility::conversions::to_utf8string(namespaceName).c_str();
-	  xmlTextWriterStartElementNS(m_writer,valueXmlPrefix,valueXmlName,valueXmlNamespace);
-	}
+        if (elementPrefix.empty() && namespaceName.empty())
+        {
+            xmlTextWriterStartElement(m_writer, valueXmlName);
+        }
+        else
+        {
+            xmlChar* valueXmlPrefix = elementPrefix.empty() ? NULL : (xmlChar*) ::odata::utility::conversions::to_utf8string(elementPrefix).c_str();
+            xmlChar* valueXmlNamespace = namespaceName.empty() ? NULL : (xmlChar*) ::odata::utility::conversions::to_utf8string(namespaceName).c_str();
+            xmlTextWriterStartElementNS(m_writer, valueXmlPrefix, valueXmlName, valueXmlNamespace);
+        }
 #endif
     }
 
@@ -511,16 +511,16 @@ namespace odata { namespace edm {
 #else
         xmlChar* nameXml = (xmlChar*) ::odata::utility::conversions::to_utf8string(name).c_str();
         xmlChar* valueXml = (xmlChar*) ::odata::utility::conversions::to_utf8string(value).c_str();
-	if(prefix.empty())
-	{
-	  xmlTextWriterWriteAttribute(m_writer, nameXml, valueXml);
-	}
-	else
-	{
-	  xmlChar* valueXmlPrefix = (xmlChar*) ::odata::utility::conversions::to_utf8string(prefix).c_str();
-	  xmlChar* valueXmlNamespace = namespaceUri.empty() ? NULL : (xmlChar*) ::odata::utility::conversions::to_utf8string(namespaceUri).c_str();
-	  xmlTextWriterWriteAttributeNS(m_writer, valueXmlPrefix, nameXml, valueXmlNamespace, valueXml);
-	}
+        if (prefix.empty() && namespaceUri.empty())
+        {
+            xmlTextWriterWriteAttribute(m_writer, nameXml, valueXml);
+        }
+        else
+        {
+            xmlChar* valueXmlPrefix = prefix.empty() ? NULL : (xmlChar*) ::odata::utility::conversions::to_utf8string(prefix).c_str();
+            xmlChar* valueXmlNamespace = namespaceUri.empty() ? NULL : (xmlChar*) ::odata::utility::conversions::to_utf8string(namespaceUri).c_str();
+            xmlTextWriterWriteAttributeNS(m_writer, valueXmlPrefix, nameXml, valueXmlNamespace, valueXml);
+        }
 #endif
     }
 


### PR DESCRIPTION
Modified /src/common/xmlhelpers.cpp
Line 392: 
    - call to xmlTextWriterFlush() was missing on linux code
Lines 412-422 & 513-514:
    - Fix issue #16 : invalid call to xmlFree() lead linux program to crash  
    - Fix Linux code not supporting prefix nor namespace
